### PR TITLE
Release version 3.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.1.8 - 2026-08-05
+
+### Added
+- Added `close-menu: true` for custom menu items so player-run commands can open their own GUI after SellGUI closes.
+
+### Changed
+- Set the plugin API baseline to Paper `1.21` while retaining Java 17 bytecode compatibility for the Paper `1.21.x` through `26.3` range.
+
+### Verified
+- Built against Paper `1.21.11-R0.1-SNAPSHOT` with Java 17 bytecode output.
+
 ## 3.1.7 - 2026-07-12
 
 ### Added

--- a/SellGUI-DynaShop/pom.xml
+++ b/SellGUI-DynaShop/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.aov.sellgui</groupId>
     <artifactId>SellGUI-DynaShop</artifactId>
-    <version>3.1.7</version>
+    <version>3.1.8</version>
     
     <name>SellGUI-DynaShop</name>
     <url>https://github.com/NguyenSonhoa/SellGUI</url>
@@ -34,9 +34,9 @@
         <dependency>
             <groupId>me.aov.sellgui</groupId>
             <artifactId>SellGUI</artifactId>
-            <version>3.1.7</version>
+            <version>3.1.8</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/../target/SellGUI-3.1.7.jar</systemPath>
+            <systemPath>${project.basedir}/../target/SellGUI-3.1.8.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>net.brcdev</groupId>

--- a/SellGUI-DynaShop/src/main/resources/plugin.yml
+++ b/SellGUI-DynaShop/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.aov.sellgui.dynashop.SellGUIDynaShop
-version: 3.1.7
+version: 3.1.8
 name: SellGUI-DynaShop
 author: Rozen
-api-version: '1.20.6'
+api-version: '1.21'
 depend: [SellGUI, ShopGUIPlus, ShopGUIPlus-DynaShop]

--- a/SellGUI-DynamicShop/pom.xml
+++ b/SellGUI-DynamicShop/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.aov.sellgui</groupId>
     <artifactId>SellGUI-DynamicShop</artifactId>
-    <version>3.1.7</version>
+    <version>3.1.8</version>
 
     <name>SellGUI-DynamicShop</name>
     <url>https://github.com/NguyenSonhoa/SellGUI</url>
@@ -34,9 +34,9 @@
         <dependency>
             <groupId>me.aov.sellgui</groupId>
             <artifactId>SellGUI</artifactId>
-            <version>3.1.7</version>
+            <version>3.1.8</version>
             <scope>system</scope>
-            <systemPath>${project.basedir}/../target/SellGUI-3.1.7.jar</systemPath>
+            <systemPath>${project.basedir}/../target/SellGUI-3.1.8.jar</systemPath>
         </dependency>
     </dependencies>
 

--- a/SellGUI-DynamicShop/src/main/resources/plugin.yml
+++ b/SellGUI-DynamicShop/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.aov.sellgui.dynamicshop.SellGUIDynamicShop
-version: 3.1.7
+version: 3.1.8
 name: SellGUI-DynamicShop
 author: AOOV,SaneNuyan
-api-version: '1.20.6'
+api-version: '1.21'
 depend: [SellGUI, DynamicShop]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.aov.sellgui</groupId>
     <artifactId>SellGUI</artifactId>
-    <version>3.1.7</version>
+    <version>3.1.8</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
@@ -118,20 +118,18 @@
             <version>2.15.5</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Kyori (Optional) -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
             <version>4.26.1</version>
             <scope>compile</scope>
         </dependency>
-
-<dependency>
-    <groupId>net.kyori</groupId>
-    <artifactId>adventure-platform-bukkit</artifactId>
-    <version>4.3.2</version>
-    <scope>compile</scope>
-</dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bukkit</artifactId>
+            <version>4.3.2</version>
+            <scope>compile</scope>
+        </dependency>
 <!-- Vault (Required) -->
         <dependency>
             <groupId>com.github.MilkBowl</groupId>

--- a/src/main/java/me/aov/sellgui/SellGUI.java
+++ b/src/main/java/me/aov/sellgui/SellGUI.java
@@ -252,12 +252,15 @@ public class SellGUI implements Listener, InventoryHolder {
 
             NamespacedKey key = new NamespacedKey(main, "custom-menu-item");
             NamespacedKey senderKey = new NamespacedKey(main, "custom-menu-item-sender");
+            NamespacedKey closeMenuKey = new NamespacedKey(main, "custom-menu-item-close-menu");
             String commands = main.getCustomMenuItemsConfig().getStringList(itemPath + ".commands").stream()
                     .map(command -> command.replace("%player%", player.getName()))
                     .collect(Collectors.joining(";"));
             itemMeta.getPersistentDataContainer().set(key, PersistentDataType.STRING, commands);
             itemMeta.getPersistentDataContainer().set(senderKey, PersistentDataType.STRING,
                     main.getCustomMenuItemsConfig().getString(itemPath + ".sender", "console").toLowerCase());
+            itemMeta.getPersistentDataContainer().set(closeMenuKey, PersistentDataType.BYTE,
+                    (byte) (main.getCustomMenuItemsConfig().getBoolean(itemPath + ".close-menu", false) ? 1 : 0));
             customItem.setItemMeta(itemMeta);
             menu.setItem(slot, customItem);
         }

--- a/src/main/java/me/aov/sellgui/listeners/InventoryListeners.java
+++ b/src/main/java/me/aov/sellgui/listeners/InventoryListeners.java
@@ -176,10 +176,22 @@ public class InventoryListeners implements Listener {
     private void handleCustomMenuItemClick(Player player, ItemStack item) {
         NamespacedKey key = new NamespacedKey(main, "custom-menu-item");
         NamespacedKey senderKey = new NamespacedKey(main, "custom-menu-item-sender");
+        NamespacedKey closeMenuKey = new NamespacedKey(main, "custom-menu-item-close-menu");
         String commands = item.getItemMeta().getPersistentDataContainer().get(key, PersistentDataType.STRING);
         String sender = item.getItemMeta().getPersistentDataContainer().get(senderKey, PersistentDataType.STRING);
+        Byte closeMenu = item.getItemMeta().getPersistentDataContainer().get(closeMenuKey, PersistentDataType.BYTE);
 
         if (commands != null && !commands.isEmpty()) {
+            if (closeMenu != null && closeMenu == 1) {
+                player.closeInventory();
+                Bukkit.getScheduler().runTask(main, () -> executeCustomMenuCommands(player, commands, sender));
+                return;
+            }
+            executeCustomMenuCommands(player, commands, sender);
+        }
+    }
+
+    private void executeCustomMenuCommands(Player player, String commands, String sender) {
             String[] commandArray = commands.split(";");
             for (String command : commandArray) {
                 if (!command.trim().isEmpty()) {
@@ -199,7 +211,6 @@ public class InventoryListeners implements Listener {
                     }
                 }
             }
-        }
     }
 
     private void dropItems(Inventory inventory, Player player) {

--- a/src/main/resources/custommenuitems.yml
+++ b/src/main/resources/custommenuitems.yml
@@ -12,6 +12,7 @@ example-item:
     - "fishing"
   disabled: false
   sender: "console"
+  close-menu: false
   lore:
     - "Example Lore"
   commands:
@@ -46,6 +47,7 @@ fishing-info:
 #     - "fishing"
 #   disabled: [boolean] = if true, the item will be replaced by the fill-item
 #   sender: "console|player|op" = Command sender. Default: console. op temporarily grants OP to clicking player.
+#   close-menu: [boolean] = Close the SellGUI before executing commands. Default: false.
 #   lore: = lore list of the item, can be empty. For no lore do "lore: " with no trailing lines of strings
 #     - "[Line]"
 #   commands: = Commands run using sender. Leading / is optional.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: SellGUI
-version: '3.1.7'
+version: '3.1.8'
 main: me.aov.sellgui.SellGUIMain
-api-version: '1.20.6'
+api-version: '1.21'
 description: SellGUI plugin
 author: AOOV,SaneNuyan
 website: https://www.spigotmc.org/resources/sellgui.127355/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom menu items can optionally close the SellGUI before executing their commands.
  * Added configuration guidance for the new `close-menu` option, which defaults to disabled.

* **Compatibility**
  * Updated the plugin for the Paper 1.21 API and Java 17 compatibility.
  * Verified compatibility with Paper 1.21.11.

* **Release**
  * Released version 3.1.8 across supported SellGUI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->